### PR TITLE
refactor: replace css reset

### DIFF
--- a/src/components/site-wrapper/site-wrapper.module.scss
+++ b/src/components/site-wrapper/site-wrapper.module.scss
@@ -4,6 +4,8 @@
     min-height: 100vh;
     display: flex;
     flex-direction: column;
+    /* create a stacking context for the app */
+    isolation: isolate;
 }
 
 .content {

--- a/src/components/site-wrapper/site-wrapper.tsx
+++ b/src/components/site-wrapper/site-wrapper.tsx
@@ -14,7 +14,7 @@ export interface SiteWrapperProps {
  */
 export const SiteWrapper = ({ className, children }: SiteWrapperProps) => {
     return (
-        <div id="root" className={classNames(styles.root, className)}>
+        <div className={classNames(styles.root, className)}>
             <Header />
             <div className={styles.content}>{children}</div>
             <Footer />

--- a/src/components/site-wrapper/site-wrapper.tsx
+++ b/src/components/site-wrapper/site-wrapper.tsx
@@ -14,7 +14,7 @@ export interface SiteWrapperProps {
  */
 export const SiteWrapper = ({ className, children }: SiteWrapperProps) => {
     return (
-        <div className={classNames(styles.root, className)}>
+        <div id="root" className={classNames(styles.root, className)}>
             <Header />
             <div className={styles.content}>{children}</div>
             <Footer />

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -20,3 +20,8 @@ body {
     min-width: 320px;
     min-height: 100vh;
 }
+
+#root {
+    /* create a stacking context for the app */
+    isolation: isolate;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -20,8 +20,3 @@ body {
     min-width: 320px;
     min-height: 100vh;
 }
-
-#root {
-    /* create a stacking context for the app */
-    isolation: isolate;
-}

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -1,119 +1,66 @@
-/***
-    The new CSS reset - version 1.11.2 (last updated 15.11.2023)
-    GitHub page: https://github.com/elad2412/the-new-css-reset
-***/
-
-/*
-    Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
-    - The "symbol *" part is to solve Firefox SVG sprite bug
-    - The "html" element is excluded, otherwise a bug in Chrome breaks the CSS hyphens property (https://github.com/elad2412/the-new-css-reset/issues/36)
+/* Josh Comeau CSS Reset 
+ * Source: https://www.joshwcomeau.com/css/custom-css-reset/
+ * Description: A modern CSS reset to improve consistency and control over default styles.
  */
-*:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
-  all: unset;
-  display: revert;
-}
 
-/* Preferred box-sizing value */
+/* 1. Use a more-intuitive box-sizing model */
 *,
 *::before,
 *::after {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
-
-/* Fix mobile Safari increase font-size on landscape mode */
-html {
-  -moz-text-size-adjust: none;
-  -webkit-text-size-adjust: none;
-  text-size-adjust: none;
+/* 2. Remove default margin */
+* {
+    margin: 0;
 }
-
-/* Reapply the pointer cursor for anchor tags */
-a,
-button {
-  cursor: revert;
+body {
+    /* 3. Add accessible line-height */
+    line-height: 1.5;
+    /* 4. Improve text rendering */
+    -webkit-font-smoothing: antialiased;
 }
-
-/* Remove list styles (bullets/numbers) */
-ol,
-ul,
-menu,
-summary {
-  list-style: none;
+/* 5. Improve media defaults */
+img,
+picture,
+video,
+canvas,
+svg {
+    display: block;
+    max-width: 100%;
 }
-
-/* For images to not be able to exceed their container */
-img {
-  max-inline-size: 100%;
-  max-block-size: 100%;
-  /* to avoid the gap created by a space char between inline elements */
-  vertical-align: bottom;
-}
-
-/* removes spacing between cells in tables */
-table {
-  border-collapse: collapse;
-}
-
-/* Safari - solving issue when using user-select:none on the <body> text input doesn't working */
+/* 6. Inherit fonts for form controls */
 input,
-textarea {
-  user-select: auto;
-  -webkit-user-select: auto;
+button,
+textarea,
+select {
+    font: inherit;
+}
+/* 7. Avoid text overflows */
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    overflow-wrap: break-word;
+}
+/* 8. Improve line wrapping */
+p {
+    text-wrap: pretty;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    text-wrap: balance;
 }
 
-/* revert the 'white-space' property for textarea elements on Safari */
-textarea {
-  white-space: revert;
-}
+/* Custom additions to the original Josh Comeau reset by Codux */
 
-/* minimum style to allow to style meter element */
-meter {
-  -webkit-appearance: revert;
-  appearance: revert;
-}
-
-/* preformatted text - use only for this feature */
-:where(pre) {
-  all: revert;
-  box-sizing: border-box;
-}
-
-/* reset default text opacity of input placeholder */
-::placeholder {
-  color: unset;
-}
-
-/* fix the feature of 'hidden' attribute.
-   display:revert; revert to element instead of attribute */
-:where([hidden]) {
-  display: none;
-}
-
-/* revert for bug in Chromium browsers
-   - fix for the content editable attribute will work properly.
-   - webkit-user-select: auto; added for Safari in case of using user-select:none on wrapper element*/
-:where([contenteditable]:not([contenteditable="false"])) {
-  -moz-user-modify: read-write;
-  -webkit-user-modify: read-write;
-  overflow-wrap: break-word;
-  line-break: after-white-space;
-  -webkit-line-break: after-white-space;
-  user-select: auto;
-  -webkit-user-select: auto;
-}
-
-/* apply back the draggable feature - exist only in Chromium and Safari */
-:where([draggable="true"]) {
-  -webkit-user-drag: element;
-}
-
-/* Revert Modal native behavior */
-:where(dialog:modal) {
-  all: revert;
-  box-sizing: border-box;
-}
-
-/* Remove details summary webkit styles */
-::-webkit-details-marker {
-  display: none;
+a {
+    text-decoration: none;
+    color: inherit;
 }


### PR DESCRIPTION
This PR replaces the existing aggressive CSS reset with the [Josh Comeau CSS reset](https://www.joshwcomeau.com/css/custom-css-reset/), aiming to preserve the basic styling of HTML elements when unstyled.

### Changes in this PR:
- Replaced the current CSS reset with a simpler approach to maintain default element styles.
- Set a stacking context for the site wrapper.